### PR TITLE
Use cmake toolchain file if possible

### DIFF
--- a/lib/mix/tasks/cmake/config.ex
+++ b/lib/mix/tasks/cmake/config.ex
@@ -44,6 +44,14 @@ defmodule  Mix.Tasks.Cmake.Config do
     cmake_env = Cmake.default_env()
       |> Cmake.add_env("CMAKE_GENERATOR", cmake_config[:generator])
 
+    # specify toolchain file for cross-compilation if available
+    cmake_toolchain_file = System.get_env("CMAKE_TOOLCHAIN_FILE")
+
+    cmake_args =
+      if cmake_toolchain_file,
+        do: ["-DCMAKE_TOOLCHAIN_FILE=#{cmake_toolchain_file}" | cmake_args],
+        else: cmake_args
+
     # construct cmake args
     cmake_args = if build_dir == :global,
       do:   ["-UCMAKE_HOME_DIRECTORY", "-UCONFU_DEPENDENCIES_SOURCE_DIR" | cmake_args], # add options to remove some cache entries


### PR DESCRIPTION
This checks the `CMAKE_TOOLCHAIN_FILE` for whether there's a CMake
toolchain file that can be used from configuring the builds. The Nerves
tooling exports `$CMAKE_TOOLCHAIN_FILE` in the Nerves systems using
`nerves_system_br v1.18.3` and later.
